### PR TITLE
Add Docker Local Runtime (Spring Boot + Postgres) With Docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+.idea
+target
+.DS_Store
+.env
+*.iml
+README.md
+LICENSE
+openapi.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM maven:3.9.11-eclipse-temurin-21 AS build
+WORKDIR /app
+
+COPY pom.xml .
+COPY .mvn .mvn
+COPY mvnw mvnw
+COPY src src
+
+RUN chmod +x mvnw && ./mvnw -B -DskipTests clean package
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+
+RUN useradd --system --uid 1001 appuser
+
+COPY --from=build /app/target/*.jar /app/app.jar
+
+USER appuser
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/README.md
+++ b/README.md
@@ -127,6 +127,57 @@ http://localhost:8080
 
 Flyway migrations run on startup, and Hibernate is configured with `ddl-auto=validate`.
 
+## Run With Docker
+
+### Prerequisite
+
+- Docker Desktop (or Docker Engine + Compose)
+
+### Start App + Postgres
+
+Set your TMDB token and start both services:
+
+```bash
+export TMDB_ACCESS_TOKEN=your_tmdb_access_token
+docker compose up --build
+```
+
+Run in background (detached mode):
+
+```bash
+docker compose up --build -d
+```
+
+### Smoke Test
+
+In a separate terminal:
+
+```bash
+curl -i http://localhost:8080/users
+```
+
+Expected: `HTTP/1.1 200` and usually `[]` on a fresh DB.
+
+To verify TMDB integration specifically:
+
+```bash
+curl -i "http://localhost:8080/movies/popular"
+```
+
+### Stop / Cleanup
+
+Stop containers but keep database data:
+
+```bash
+docker compose down
+```
+
+Stop containers and remove database volume (`pgdata`):
+
+```bash
+docker compose down -v
+```
+
 ## Build and Test
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+services:
+  postgres:
+    image: postgres:16
+    container_name: mowizz-postgres
+    environment:
+      POSTGRES_DB: mowizz
+      POSTGRES_USER: mowizz
+      POSTGRES_PASSWORD: mowizz
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U mowizz -d mowizz"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  app:
+    container_name: mowizz-server
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: mowizz-server:local
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DB_URL: jdbc:postgresql://postgres:5432/mowizz
+      DB_USERNAME: mowizz
+      DB_PASSWORD: mowizz
+      TMDB_ACCESS_TOKEN: ${TMDB_ACCESS_TOKEN:-dev-token}
+      SPRING_JPA_HIBERNATE_DDL_AUTO: update
+    ports:
+      - "8080:8080"
+
+volumes:
+  pgdata:


### PR DESCRIPTION
### Summary
Adds Docker-based local runtime support so the backend and PostgreSQL can be started with one command.

### Changes
- Added `dockerfile`
    - Multi-stage build (Maven build + Java 21 runtime)
    - Runs as non-root user
- Added `.dockerignore`
    - Excludes local/dev artifacts and reduces build context
- Added `docker-compose.yml`
     - `app` service + `postgres` service
     - Postgres healthcheck and startup dependency for app
     - Env wiring for DB and TMDB token
     - Local dev override: `SPRING_JPA_HIBERNATE_DDL_AUTO=update`
- Updated `README.md`
     - Docker setup, run modes, smoke tests, and cleanup commands

### Validation
- `docker compose up --build` starts both services
- `curl -i http://localhost:8080/users` returns `1.1 200` with `[]` on fresh DB
- `./mvnw -q clean verify` passes

### Notes
- Flyway migrations are currently empty; local Docker relies on JPA update to create tables.
- This is intended for local development. Production should rely on explicit migrations and strict schema validation.

### Linked Issues
- closes #13 