### PR TITLE
refactor(user-media): rename AddUserMediaRequestDTO and fix delete endpoint contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Controller → Service → Repository (JPA / PostgreSQL)
 - **`dto/`** — Own API types, separate from TMDB wire format types:
   - `MovieResponseDTO`, `TvShowResponseDTO` — full detail response payloads (camelCase fields)
   - `MovieSearchResultDTO`, `TvShowSearchResultDTO` — lightweight search result payloads, both implement the `SearchResultDTO` sealed interface
-  - `AddUserMediaRequestDTO` — request body for the user media endpoint
+  - `UserMediaRequestDTO` — request body for the user media endpoints (add and delete)
 - **`error/GlobalExceptionHandler`** — `@RestControllerAdvice` mapping custom exceptions to HTTP status codes (e.g. `TmdbClientException` → 503, `UserNotFoundException` → 404, `MediaAlreadyExistsException` → 409).
 
 **Database:** PostgreSQL (Supabase) in production; Flyway manages migrations with `baseline-on-migrate=true` and Hibernate set to `ddl-auto=validate`. The `db/migration/` directory is currently empty — schema is created by `ddl-auto=update` in Docker Compose.

--- a/README.md
+++ b/README.md
@@ -212,7 +212,8 @@ docker compose down -v
 - `POST /users/{user_id}/media` — add a movie or TV show to a user's watchlist
   request body example: `{ "tmdbId": 12345, "mediaType": "MOVIE" }`
 - `GET /users/{user_id}/media` — list all watchlist items for a user
-- `DELETE /users/{user_id}/media/{media_id}` — remove a watchlist item
+- `DELETE /users/{user_id}/media` — remove a watchlist item
+  request body example: `{ "tmdbId": 12345, "mediaType": "MOVIE" }`
 
 ## OpenAPI
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -293,7 +293,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AddUserMediaRequest"
+              $ref: "#/components/schemas/UserMediaRequest"
       responses:
         "200":
           description: User media entry created
@@ -328,7 +328,7 @@ paths:
         "404":
           description: User not found
 
-  /users/{user_id}/media/{media_id}:
+  /users/{user_id}/media:
     delete:
       tags: [User Media]
       operationId: deleteMediaForUser
@@ -340,12 +340,12 @@ paths:
           schema:
             type: integer
             format: int64
-        - in: path
-          name: media_id
-          required: true
-          schema:
-            type: integer
-            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UserMediaRequest"
       responses:
         "200":
           description: Media removed
@@ -363,7 +363,7 @@ components:
         username:
           type: string
 
-    AddUserMediaRequest:
+    UserMediaRequest:
       type: object
       required:
         - tmdbId

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <release>${java.version}</release>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.projectlombok</groupId>

--- a/src/main/java/com/github/davidduclam/movietracker/controller/UserMediaController.java
+++ b/src/main/java/com/github/davidduclam/movietracker/controller/UserMediaController.java
@@ -1,6 +1,6 @@
 package com.github.davidduclam.movietracker.controller;
 
-import com.github.davidduclam.movietracker.dto.AddUserMediaRequestDTO;
+import com.github.davidduclam.movietracker.dto.UserMediaRequestDTO;
 import com.github.davidduclam.movietracker.dto.WatchlistItemDTO;
 import com.github.davidduclam.movietracker.model.UserMedia;
 import com.github.davidduclam.movietracker.service.UserMediaService;
@@ -19,8 +19,8 @@ public class UserMediaController {
     }
 
     @PostMapping("/users/{user_id}/media")
-    public UserMedia saveMediaToDb(@PathVariable Long user_id, @Valid @RequestBody AddUserMediaRequestDTO addUserMediaRequestDTO) {
-        return userMediaService.addMediaToUser(user_id, addUserMediaRequestDTO);
+    public UserMedia saveMediaToDb(@PathVariable Long user_id, @Valid @RequestBody UserMediaRequestDTO userMediaRequestDTO) {
+        return userMediaService.addMediaToUser(user_id, userMediaRequestDTO);
     }
 
     @GetMapping("/users/{user_id}/media")
@@ -28,8 +28,8 @@ public class UserMediaController {
         return userMediaService.getMediaFromUser(user_id);
     }
 
-    @DeleteMapping("/users/{user_id}/media/{media_id}")
-    public void deleteMediaFromUser(@PathVariable Long user_id, @PathVariable Long media_id) {
-        userMediaService.deleteMediaFromUser(user_id, media_id);
+    @DeleteMapping("/users/{user_id}/media")
+    public void deleteMediaFromUser(@PathVariable Long user_id, @Valid @RequestBody UserMediaRequestDTO userMediaRequestDTO) {
+        userMediaService.deleteMediaFromUser(user_id, userMediaRequestDTO);
     }
 }

--- a/src/main/java/com/github/davidduclam/movietracker/dto/UserMediaRequestDTO.java
+++ b/src/main/java/com/github/davidduclam/movietracker/dto/UserMediaRequestDTO.java
@@ -3,7 +3,7 @@ package com.github.davidduclam.movietracker.dto;
 import com.github.davidduclam.movietracker.model.MediaType;
 import jakarta.validation.constraints.NotNull;
 
-public record AddUserMediaRequestDTO(
+public record UserMediaRequestDTO(
     @NotNull(message = "tmdbId is required")
     Long tmdbId,
 

--- a/src/main/java/com/github/davidduclam/movietracker/repository/UserMediaRepository.java
+++ b/src/main/java/com/github/davidduclam/movietracker/repository/UserMediaRepository.java
@@ -13,5 +13,5 @@ public interface UserMediaRepository extends JpaRepository<UserMedia, Long> {
 
     boolean existsByUserIdAndMediaTypeAndTmdbId(Long user_id, MediaType mediaType, Long tmdbId);
 
-    Optional<UserMedia> findByIdAndUserId(Long id, Long userId);
+    Optional<UserMedia> findByUserIdAndTmdbIdAndMediaType(Long userId, Long tmdbId, MediaType mediaType);
 }

--- a/src/main/java/com/github/davidduclam/movietracker/service/MovieService.java
+++ b/src/main/java/com/github/davidduclam/movietracker/service/MovieService.java
@@ -2,12 +2,11 @@ package com.github.davidduclam.movietracker.service;
 
 import com.github.davidduclam.movietracker.client.tmdb.TmdbClient;
 import com.github.davidduclam.movietracker.client.tmdb.dto.TmdbVideoDTO;
-import com.github.davidduclam.movietracker.dto.AddUserMediaRequestDTO;
+import com.github.davidduclam.movietracker.dto.UserMediaRequestDTO;
 import com.github.davidduclam.movietracker.client.tmdb.dto.TmdbMovieDTO;
 import com.github.davidduclam.movietracker.dto.MovieResponseDTO;
 import com.github.davidduclam.movietracker.dto.TrailerDTO;
 import com.github.davidduclam.movietracker.error.MediaNotFoundException;
-import com.github.davidduclam.movietracker.error.TmdbClientException;
 import com.github.davidduclam.movietracker.model.Movie;
 import com.github.davidduclam.movietracker.repository.MovieRepository;
 import org.springframework.stereotype.Service;
@@ -51,12 +50,12 @@ public class MovieService {
      * If not, it fetches the movie details from TMDb, converts the details to a Movie entity,
      * and saves it to the database.
      *
-     * @param addUserMediaRequestDTO the data transfer object containing information about the movie to be added,
+     * @param userMediaRequestDTO the data transfer object containing information about the movie to be added,
      *                               including the TMDb ID required to fetch the movie details.
      */
-    public void saveMovieToDb(AddUserMediaRequestDTO addUserMediaRequestDTO) {
-        if (movieRepository.findByTmdbId(addUserMediaRequestDTO.tmdbId()).isEmpty()) {
-            Movie movie = convertMovieResponseDtoToMovie(fetchMovieDetails(addUserMediaRequestDTO.tmdbId()));
+    public void saveMovieToDb(UserMediaRequestDTO userMediaRequestDTO) {
+        if (movieRepository.findByTmdbId(userMediaRequestDTO.tmdbId()).isEmpty()) {
+            Movie movie = convertMovieResponseDtoToMovie(fetchMovieDetails(userMediaRequestDTO.tmdbId()));
             movieRepository.save(movie);
         }
     }

--- a/src/main/java/com/github/davidduclam/movietracker/service/TvShowService.java
+++ b/src/main/java/com/github/davidduclam/movietracker/service/TvShowService.java
@@ -2,13 +2,11 @@ package com.github.davidduclam.movietracker.service;
 
 import com.github.davidduclam.movietracker.client.tmdb.TmdbClient;
 import com.github.davidduclam.movietracker.client.tmdb.dto.TmdbVideoDTO;
-import com.github.davidduclam.movietracker.dto.AddUserMediaRequestDTO;
+import com.github.davidduclam.movietracker.dto.UserMediaRequestDTO;
 import com.github.davidduclam.movietracker.client.tmdb.dto.TmdbTvShowDTO;
-import com.github.davidduclam.movietracker.dto.MovieResponseDTO;
 import com.github.davidduclam.movietracker.dto.TrailerDTO;
 import com.github.davidduclam.movietracker.dto.TvShowResponseDTO;
 import com.github.davidduclam.movietracker.error.MediaNotFoundException;
-import com.github.davidduclam.movietracker.error.TmdbClientException;
 import com.github.davidduclam.movietracker.model.TvShow;
 import com.github.davidduclam.movietracker.repository.TvShowRepository;
 import org.springframework.stereotype.Service;
@@ -56,12 +54,12 @@ public class TvShowService {
      * from an external API, converts the fetched data into a {@code TvShow}
      * entity, and saves it to the repository.
      *
-     * @param addUserMediaRequestDTO the DTO containing the TMDB ID of the
+     * @param userMediaRequestDTO the DTO containing the TMDB ID of the
      *                                TV show to be saved
      */
-    public void saveTvShowToDb(AddUserMediaRequestDTO addUserMediaRequestDTO) {
-        if (tvShowRepository.findByTmdbId(addUserMediaRequestDTO.tmdbId()).isEmpty()) {
-            TvShow tvShow = convertTvShowResponseDtoToTvShow(fetchTvShowDetails(addUserMediaRequestDTO.tmdbId()));
+    public void saveTvShowToDb(UserMediaRequestDTO userMediaRequestDTO) {
+        if (tvShowRepository.findByTmdbId(userMediaRequestDTO.tmdbId()).isEmpty()) {
+            TvShow tvShow = convertTvShowResponseDtoToTvShow(fetchTvShowDetails(userMediaRequestDTO.tmdbId()));
             tvShowRepository.save(tvShow);
         }
     }
@@ -159,7 +157,6 @@ public class TvShowService {
                 tmdbVideoDTO.site()
         );
     }
-
 
     /**
      * Converts a {@code TmdbTvShowDTO} object into a {@code TvShowResponseDTO}.

--- a/src/main/java/com/github/davidduclam/movietracker/service/UserMediaService.java
+++ b/src/main/java/com/github/davidduclam/movietracker/service/UserMediaService.java
@@ -37,24 +37,24 @@ public class UserMediaService {
      * - Saves the UserMedia entity associating the user with the specified media.
      *
      * @param userId The unique identifier of the user to whom the media is to be added.
-     * @param addUserMediaRequestDTO A data transfer object containing the information about the media
+     * @param userMediaRequestDTO A data transfer object containing the information about the media
      *                                to be added, including its TMDb ID and media type (e.g., movie or TV show).
      * @return The UserMedia entity representing the association between the user and the added media.
      * @throws UserNotFoundException If the specified user does not exist.
      * @throws MediaAlreadyExistsException If the media has already been added to the user's collection.
      */
     @Transactional
-    public UserMedia addMediaToUser(Long userId, AddUserMediaRequestDTO addUserMediaRequestDTO) {
+    public UserMedia addMediaToUser(Long userId, UserMediaRequestDTO userMediaRequestDTO) {
         User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
 
-        saveMediaToMovieOrTvShowDb(addUserMediaRequestDTO);
+        saveMediaToMovieOrTvShowDb(userMediaRequestDTO);
 
-        if (userMediaRepository.existsByUserIdAndMediaTypeAndTmdbId(userId, addUserMediaRequestDTO.mediaType(), addUserMediaRequestDTO.tmdbId())) {
+        if (userMediaRepository.existsByUserIdAndMediaTypeAndTmdbId(userId, userMediaRequestDTO.mediaType(), userMediaRequestDTO.tmdbId())) {
             throw new MediaAlreadyExistsException();
         }
 
-        return saveUserMediaToDb(user, addUserMediaRequestDTO);
+        return saveUserMediaToDb(user, userMediaRequestDTO);
     }
 
     /**
@@ -85,23 +85,25 @@ public class UserMediaService {
     }
 
     /**
-     * Deletes a specific media item associated with a given user.
+     * Deletes a specific piece of media associated with a user based on the provided user ID
+     * and media details.
      *
-     * @param userId the ID of the user whose media is to be deleted
-     * @param mediaId the ID of the media to be deleted
-     * @throws UserNotFoundException if the user with the specified ID is not found
-     * @throws MediaNotFoundException if the media with the specified ID is not found for the user
+     * @param userId the unique identifier of the user for whom the media is to be deleted
+     * @param userMediaRequestDTO an object containing the details of the media to be deleted,
+     *                            such as the TMDB ID and media type
+     * @throws UserNotFoundException if the user with the specified ID does not exist
+     * @throws MediaNotFoundException if the specified media is not associated with the user
      */
     @Transactional
-    public void deleteMediaFromUser(Long userId, Long mediaId) {
+    public void deleteMediaFromUser(Long userId, UserMediaRequestDTO userMediaRequestDTO) {
         User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
 
         UserMedia userMedia = userMediaRepository
-                .findByIdAndUserId(mediaId, userId)
+                .findByUserIdAndTmdbIdAndMediaType(userId, userMediaRequestDTO.tmdbId(), userMediaRequestDTO.mediaType())
                 .orElseThrow(MediaNotFoundException::new);
 
-        userMediaRepository.deleteById(mediaId);
+        userMediaRepository.deleteById(userMedia.getId());
     }
 
     /**
@@ -151,11 +153,11 @@ public class UserMediaService {
      * Delegates the saving logic to the {@code addUserMediaToDb} method.
      *
      * @param user The User entity associated with the UserMedia to be added.
-     * @param addUserMediaRequestDTO The data transfer object containing information required to create the UserMedia entity.
+     * @param userMediaRequestDTO The data transfer object containing information required to create the UserMedia entity.
      * @return The UserMedia entity that was saved to the database.
      */
-    private UserMedia saveUserMediaToDb(User user, AddUserMediaRequestDTO addUserMediaRequestDTO) {
-        return addUserMediaToDb(user, addUserMediaRequestDTO);
+    private UserMedia saveUserMediaToDb(User user, UserMediaRequestDTO userMediaRequestDTO) {
+        return addUserMediaToDb(user, userMediaRequestDTO);
     }
 
     /**
@@ -163,19 +165,19 @@ public class UserMediaService {
      * Determines the type of media from the {@code mediaType} field in the DTO and delegates the
      * save operation to the appropriate service.
      *
-     * @param addUserMediaRequestDTO the data transfer object containing details of the media to be saved,
+     * @param userMediaRequestDTO the data transfer object containing details of the media to be saved,
      *                               including its type and TMDb ID
      * @throws IllegalArgumentException if the {@code mediaType} field in the request DTO is null
      */
-    private void saveMediaToMovieOrTvShowDb(AddUserMediaRequestDTO addUserMediaRequestDTO) {
-        if (addUserMediaRequestDTO.mediaType() == null) {
+    private void saveMediaToMovieOrTvShowDb(UserMediaRequestDTO userMediaRequestDTO) {
+        if (userMediaRequestDTO.mediaType() == null) {
             throw new IllegalArgumentException("mediaType is required");
         }
 
-        if (addUserMediaRequestDTO.mediaType() == MediaType.MOVIE) {
-            movieService.saveMovieToDb(addUserMediaRequestDTO);
+        if (userMediaRequestDTO.mediaType() == MediaType.MOVIE) {
+            movieService.saveMovieToDb(userMediaRequestDTO);
         } else {
-            tvShowService.saveTvShowToDb(addUserMediaRequestDTO);
+            tvShowService.saveTvShowToDb(userMediaRequestDTO);
         }
     }
 
@@ -183,14 +185,14 @@ public class UserMediaService {
      * Adds a new UserMedia entity to the database based on the provided user and request DTO.
      *
      * @param user The User entity associated with the UserMedia to be added.
-     * @param addUserMediaRequestDTO The data transfer object containing information required to create the UserMedia entity.
+     * @param userMediaRequestDTO The data transfer object containing information required to create the UserMedia entity.
      * @return The UserMedia entity that was saved to the database.
      */
-    private UserMedia addUserMediaToDb(User user, AddUserMediaRequestDTO addUserMediaRequestDTO) {
+    private UserMedia addUserMediaToDb(User user, UserMediaRequestDTO userMediaRequestDTO) {
         UserMedia userMedia = new UserMedia();
         userMedia.setUser(user);
-        userMedia.setTmdbId(addUserMediaRequestDTO.tmdbId());
-        userMedia.setMediaType(addUserMediaRequestDTO.mediaType());
+        userMedia.setTmdbId(userMediaRequestDTO.tmdbId());
+        userMedia.setMediaType(userMediaRequestDTO.mediaType());
 
         userMediaRepository.save(userMedia);
         return userMedia;


### PR DESCRIPTION
Closes #22

## Summary
- Rename `AddUserMediaRequestDTO` → `UserMediaRequestDTO` across all Java files, since the same request body is shared by both add and delete endpoints
- Fix `DELETE /users/{user_id}/media` to use a request body instead of a `media_id` path param, matching the actual controller implementation
- Update repository lookup for delete from `findByIdAndUserId` to `findByUserIdAndTmdbIdAndMediaType`
- Align `openapi.yaml`, `README.md`, and `CLAUDE.md` with the correct contracts

## Test plan
- [x] `POST /users/{user_id}/media` still adds media correctly
- [x] `DELETE /users/{user_id}/media` removes the correct entry by `tmdbId` + `mediaType`
- [x] Build and tests pass (`./mvnw clean verify`)