### PR TITLE
fix(openapi): merge duplicate /users/{user_id}/media path entries

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -327,8 +327,6 @@ paths:
                   $ref: "#/components/schemas/WatchlistItem"
         "404":
           description: User not found
-
-  /users/{user_id}/media:
     delete:
       tags: [User Media]
       operationId: deleteMediaForUser


### PR DESCRIPTION
## Summary
- The `DELETE /users/{user_id}/media` operation was added as a second top-level path entry instead of being nested under the existing `/users/{user_id}/media` path alongside `post` and `get`
- This caused an OpenAPI validation error: `Duplicate field /users/{user_id}/media`

## Test plan
- [x] OpenAPI spec validates without duplicate field errors