### PR TITLE
fix(openapi): add missing error responses and fix schema inaccuracies

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: MoWizz API
-  version: 1.4.0
+  version: 1.5.0
   description: OpenAPI documentation for current MoWizz server endpoints.
 servers:
   - url: http://localhost:8080
@@ -36,6 +36,18 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Movie"
+        "404":
+          description: Movie not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: TMDB service unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /movies/{tmdbId}/trailer:
     get:
@@ -59,10 +71,20 @@ paths:
                 $ref: "#/components/schemas/Trailer"
               example:
                 key: b9EkMc79ZSU
-                name: Season 1 Official Final Trailer
+                name: Official Trailer
                 site: YouTube
         "404":
           description: No trailer found for this movie
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: TMDB service unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /movies/popular:
     get:
@@ -78,6 +100,12 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Movie"
+        "503":
+          description: TMDB service unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /movies/top-rated:
     get:
@@ -93,6 +121,12 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Movie"
+        "503":
+          description: TMDB service unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /movies/upcoming:
     get:
@@ -108,6 +142,12 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Movie"
+        "503":
+          description: TMDB service unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /shows/{tmdbId}:
     get:
@@ -128,6 +168,18 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/TvShow"
+        "404":
+          description: TV show not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: TMDB service unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /shows/{tmdbId}/trailer:
     get:
@@ -155,6 +207,16 @@ paths:
                 site: YouTube
         "404":
           description: No trailer found for this TV show
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: TMDB service unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /shows/popular:
     get:
@@ -170,6 +232,12 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/TvShow"
+        "503":
+          description: TMDB service unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /shows/top-rated:
     get:
@@ -185,6 +253,12 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/TvShow"
+        "503":
+          description: TMDB service unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /search/multi:
     get:
@@ -207,6 +281,12 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/SearchResult"
+        "503":
+          description: TMDB service unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /users:
     post:
@@ -261,6 +341,10 @@ paths:
                 $ref: "#/components/schemas/User"
         "404":
           description: User not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
     delete:
       tags: [Users]
       operationId: deleteUserById
@@ -301,10 +385,30 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/UserMedia"
+        "400":
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "404":
           description: User not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "409":
           description: Media already in user's watchlist
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: TMDB service unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
     get:
       tags: [User Media]
       operationId: getMediaForUser
@@ -327,6 +431,10 @@ paths:
                   $ref: "#/components/schemas/WatchlistItem"
         "404":
           description: User not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
     delete:
       tags: [User Media]
       operationId: deleteMediaForUser
@@ -347,11 +455,29 @@ paths:
       responses:
         "200":
           description: Media removed
+        "400":
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "404":
           description: User or media not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
 components:
   schemas:
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+        message:
+          type: string
+
     User:
       type: object
       properties:
@@ -393,6 +519,7 @@ components:
         personalRating:
           type: number
           format: double
+          nullable: true
         watchDate:
           type: string
           format: date


### PR DESCRIPTION
## Summary

- Add `404` to `GET /movies/{tmdbId}` and `GET /shows/{tmdbId}` — TMDB propagates 404 for unknown IDs via `TmdbClientException`
- Add `503` to all TMDB-backed endpoints — network/connection failures produce a 503 via `TmdbClientException` with null status
- Add `400` to `POST` and `DELETE /users/{user_id}/media` — `@Valid` on the request body can trigger `MethodArgumentNotValidException` → 400
- Add `ErrorResponse` schema (`{error, message}`) matching the actual error response body returned by `GlobalExceptionHandler`, and reference it from all error responses
- Mark `UserMedia.personalRating` as `nullable: true` — the Java field is `Double` and is null on newly created entries
- Fix movie trailer example name (was "Season 1 Official Final Trailer", a TV show label)

## Test plan

- [x] Verify spec is valid OpenAPI 3.0.3 (e.g. paste into Swagger Editor)
- [x] Confirm error response shapes match `GlobalExceptionHandler` output