### PR TITLE
feat(trailer): embed trailer key in movie and TV show details response

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: MoWizz API
-  version: 1.5.0
+  version: 1.6.0
   description: OpenAPI documentation for current MoWizz server endpoints.
 servers:
   - url: http://localhost:8080
@@ -562,6 +562,10 @@ components:
         voteAverage:
           type: number
           format: double
+        trailerKey:
+          type: string
+          nullable: true
+          description: YouTube video ID of the first official trailer, or null if none exists
 
     TvShow:
       type: object
@@ -585,6 +589,10 @@ components:
         voteAverage:
           type: number
           format: double
+        trailerKey:
+          type: string
+          nullable: true
+          description: YouTube video ID of the first official trailer, or null if none exists
 
     SearchResult:
       oneOf:

--- a/src/main/java/com/github/davidduclam/movietracker/client/tmdb/TmdbClient.java
+++ b/src/main/java/com/github/davidduclam/movietracker/client/tmdb/TmdbClient.java
@@ -71,7 +71,7 @@ public class TmdbClient {
      */
     public TmdbMovieDTO fetchMovieDetails(Long tmdbId) {
         TmdbMovieDTO response = execute("fetch movie details", () -> restClient.get()
-                .uri("/movie/{movie_id}", tmdbId)
+                .uri("/movie/{movie_id}?append_to_response=videos", tmdbId)
                 .retrieve()
                 .body(TmdbMovieDTO.class));
         if (response == null) {
@@ -144,7 +144,7 @@ public class TmdbClient {
      */
     public TmdbTvShowDTO fetchTvShowDetails(Long tmdbId) {
         TmdbTvShowDTO response = execute("fetch tv show details", () -> restClient.get()
-                .uri("/tv/{series_id}", tmdbId)
+                .uri("/tv/{series_id}?append_to_response=videos", tmdbId)
                 .retrieve()
                 .body(TmdbTvShowDTO.class));
         if (response == null) {

--- a/src/main/java/com/github/davidduclam/movietracker/client/tmdb/dto/TmdbMovieDTO.java
+++ b/src/main/java/com/github/davidduclam/movietracker/client/tmdb/dto/TmdbMovieDTO.java
@@ -1,6 +1,7 @@
 package com.github.davidduclam.movietracker.client.tmdb.dto;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public record TmdbMovieDTO(
     Long id,
@@ -9,5 +10,6 @@ public record TmdbMovieDTO(
     String poster_path,
     String backdrop_path,
     String overview,
-    Double vote_average
+    Double vote_average,
+    TmdbVideoResultsDTO videos
 ) {}

--- a/src/main/java/com/github/davidduclam/movietracker/client/tmdb/dto/TmdbTvShowDTO.java
+++ b/src/main/java/com/github/davidduclam/movietracker/client/tmdb/dto/TmdbTvShowDTO.java
@@ -9,5 +9,6 @@ public record TmdbTvShowDTO(
         LocalDate first_air_date,
         String poster_path,
         String backdrop_path,
-        Double vote_average
+        Double vote_average,
+        TmdbVideoResultsDTO videos
 ) {}

--- a/src/main/java/com/github/davidduclam/movietracker/client/tmdb/dto/TmdbVideoResultsDTO.java
+++ b/src/main/java/com/github/davidduclam/movietracker/client/tmdb/dto/TmdbVideoResultsDTO.java
@@ -1,0 +1,8 @@
+package com.github.davidduclam.movietracker.client.tmdb.dto;
+
+import java.util.List;
+
+public record TmdbVideoResultsDTO(
+        List<TmdbVideoDTO> results
+) {
+}

--- a/src/main/java/com/github/davidduclam/movietracker/dto/MovieResponseDTO.java
+++ b/src/main/java/com/github/davidduclam/movietracker/dto/MovieResponseDTO.java
@@ -9,5 +9,6 @@ public record MovieResponseDTO(
     LocalDate releaseDate,
     String posterPath,
     String backdropPath,
-    Double voteAverage
+    Double voteAverage,
+    String trailerKey
 ) {}

--- a/src/main/java/com/github/davidduclam/movietracker/dto/TvShowResponseDTO.java
+++ b/src/main/java/com/github/davidduclam/movietracker/dto/TvShowResponseDTO.java
@@ -9,6 +9,7 @@ public record TvShowResponseDTO(
         LocalDate firstAirDate,
         String posterPath,
         String backdropPath,
-        Double voteAverage
+        Double voteAverage,
+        String trailerKey
 ) {}
 

--- a/src/main/java/com/github/davidduclam/movietracker/service/MovieService.java
+++ b/src/main/java/com/github/davidduclam/movietracker/service/MovieService.java
@@ -11,6 +11,7 @@ import com.github.davidduclam.movietracker.model.Movie;
 import com.github.davidduclam.movietracker.repository.MovieRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -76,7 +77,7 @@ public class MovieService {
                 .map(movie -> new MovieResponseDTO(
                         movie.getTmdbId(), movie.getTitle(), movie.getOverview(),
                         movie.getReleaseDate(), movie.getPosterPath(),
-                        movie.getBackdropPath(), movie.getVoteAverage()))
+                        movie.getBackdropPath(), movie.getVoteAverage(), null))
                 .orElseThrow(MediaNotFoundException::new);
     }
 
@@ -160,13 +161,20 @@ public class MovieService {
     }
 
     /**
-     * Converts a TmdbMovieDTO object into a MovieResponseDTO object.
+     * Converts a {@link TmdbMovieDTO} object into a {@link MovieResponseDTO} object.
      *
-     * @param tmdbMovieDTO the DTO containing movie details retrieved from TMDb
-     * @return a MovieResponseDTO object containing the movie's details, including its ID, title, release date,
-     *         poster path, backdrop path, overview, and vote average
+     * @param tmdbMovieDTO the {@link TmdbMovieDTO} object containing movie information
+     *                     retrieved from the TMDb API.
+     * @return a {@link MovieResponseDTO} object containing the transformed movie
+     *         information, including basic details and the trailer key if available.
      */
     private MovieResponseDTO toMovieResponse(TmdbMovieDTO tmdbMovieDTO) {
+        String trailerKey = tmdbMovieDTO.videos() == null ? null :
+                tmdbMovieDTO.videos().results().stream()
+                        .filter(v -> "Trailer".equals(v.type()) && Boolean.TRUE.equals(v.official()))
+                        .map(TmdbVideoDTO::key)
+                        .findFirst()
+                        .orElse(null);
         return new MovieResponseDTO(
                 tmdbMovieDTO.id(),
                 tmdbMovieDTO.title(),
@@ -174,6 +182,7 @@ public class MovieService {
                 tmdbMovieDTO.release_date(),
                 tmdbMovieDTO.poster_path(),
                 tmdbMovieDTO.backdrop_path(),
-                tmdbMovieDTO.vote_average());
+                tmdbMovieDTO.vote_average(),
+                trailerKey);
     }
 }

--- a/src/main/java/com/github/davidduclam/movietracker/service/MovieService.java
+++ b/src/main/java/com/github/davidduclam/movietracker/service/MovieService.java
@@ -171,7 +171,7 @@ public class MovieService {
     private MovieResponseDTO toMovieResponse(TmdbMovieDTO tmdbMovieDTO) {
         String trailerKey = tmdbMovieDTO.videos() == null ? null :
                 tmdbMovieDTO.videos().results().stream()
-                        .filter(v -> "Trailer".equals(v.type()) && Boolean.TRUE.equals(v.official()))
+                        .filter(v -> v.type().equals("Trailer") && v.official().equals(true) && "YouTube".equals(v.site()))
                         .map(TmdbVideoDTO::key)
                         .findFirst()
                         .orElse(null);

--- a/src/main/java/com/github/davidduclam/movietracker/service/TvShowService.java
+++ b/src/main/java/com/github/davidduclam/movietracker/service/TvShowService.java
@@ -167,7 +167,7 @@ public class TvShowService {
     private TvShowResponseDTO toTvShowResponse(TmdbTvShowDTO tmdbTvShowDTO) {
         String trailerKey = tmdbTvShowDTO.videos() == null ? null :
                 tmdbTvShowDTO.videos().results().stream()
-                        .filter(v -> "Trailer".equals(v.type()) && Boolean.TRUE.equals(v.official()))
+                        .filter(v -> v.type().equals("Trailer") && v.official().equals(true) && "YouTube".equals(v.site()))
                         .map(TmdbVideoDTO::key)
                         .findFirst()
                         .orElse(null);

--- a/src/main/java/com/github/davidduclam/movietracker/service/TvShowService.java
+++ b/src/main/java/com/github/davidduclam/movietracker/service/TvShowService.java
@@ -80,7 +80,7 @@ public class TvShowService {
                 .map(tvShow -> new TvShowResponseDTO(
                         tvShow.getTmdbId(), tvShow.getTitle(), tvShow.getOverview(),
                         tvShow.getFirstAirDate(), tvShow.getPosterPath(),
-                        tvShow.getBackdropPath(), tvShow.getVoteAverage()))
+                        tvShow.getBackdropPath(), tvShow.getVoteAverage(), null))
                 .orElseThrow(MediaNotFoundException::new);
     }
 
@@ -159,17 +159,18 @@ public class TvShowService {
     }
 
     /**
-     * Converts a {@code TmdbTvShowDTO} object into a {@code TvShowResponseDTO}.
+     * Converts a TmdbTvShowDTO object into a TvShowResponseDTO object.
      *
-     * This method maps the attributes from the {@code TmdbTvShowDTO} object, such
-     * as ID, name, overview, first air date, poster path, backdrop path, and vote
-     * average, to a new {@code TvShowResponseDTO} instance.
-     *
-     * @param tmdbTvShowDTO the DTO containing the TV show details fetched from the TMDB API
-     * @return a {@code TvShowResponseDTO} populated with the corresponding values
-     *         from the {@code TmdbTvShowDTO}
+     * @param tmdbTvShowDTO the input DTO containing data from the TMDB API about a TV show
+     * @return a TvShowResponseDTO containing the mapped data, including the trailer key if available
      */
     private TvShowResponseDTO toTvShowResponse(TmdbTvShowDTO tmdbTvShowDTO) {
+        String trailerKey = tmdbTvShowDTO.videos() == null ? null :
+                tmdbTvShowDTO.videos().results().stream()
+                        .filter(v -> "Trailer".equals(v.type()) && Boolean.TRUE.equals(v.official()))
+                        .map(TmdbVideoDTO::key)
+                        .findFirst()
+                        .orElse(null);
         return new TvShowResponseDTO(
                 tmdbTvShowDTO.id(),
                 tmdbTvShowDTO.name(),
@@ -177,6 +178,7 @@ public class TvShowService {
                 tmdbTvShowDTO.first_air_date(),
                 tmdbTvShowDTO.poster_path(),
                 tmdbTvShowDTO.backdrop_path(),
-                tmdbTvShowDTO.vote_average());
+                tmdbTvShowDTO.vote_average(),
+                trailerKey);
     }
 }


### PR DESCRIPTION
Closes #26

## Summary
- Add `?append_to_response=videos` to `TmdbClient.fetchMovieDetails` and `fetchTvShowDetails` to embed video data in a single TMDB call
- Add `TmdbVideoResultsDTO videos` field to `TmdbMovieDTO` and `TmdbTvShowDTO` to deserialize the embedded response
- Replace raw video fields with `String trailerKey` in `MovieResponseDTO` and `TvShowResponseDTO`
- Extract the first official `type = "Trailer"` entry's key in `toMovieResponse` and `toTvShowResponse`; `null` if none exists
- Update `openapi.yaml`: add `trailerKey` to `Movie` and `TvShow` schemas, bump version to 1.6.0

## Test plan
- [x] `GET /movies/{tmdbId}` returns `trailerKey` with a YouTube key when a trailer exists
- [x] `GET /shows/{tmdbId}` returns `trailerKey` with a YouTube key when a trailer exists
- [x] `trailerKey` is `null` for media with no official trailer (not a 404 or 500)
- [x] Only one TMDB API call is made per details request
- [x] Build and tests pass